### PR TITLE
Optionally do not install MLIR libraries

### DIFF
--- a/flang/cmake/modules/AddFlang.cmake
+++ b/flang/cmake/modules/AddFlang.cmake
@@ -48,7 +48,7 @@ function(add_flang_library name)
       ADDITIONAL_HEADERS
       ${srcs}
       ${ARG_ADDITIONAL_HEADERS}) # It may contain unparsed unknown args.
-      
+
   endif()
 
   if(ARG_SHARED AND ARG_STATIC)
@@ -75,7 +75,7 @@ function(add_flang_library name)
 
   if (TARGET ${name})
 
-    if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY OR ${name} STREQUAL "libflang"
+    if ((NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND NOT MLIR_INSTALL_TOOLCHAIN_ONLY) OR ${name} STREQUAL "libflang"
         OR ARG_INSTALL_WITH_TOOLCHAIN)
       get_target_export_arg(${name} Flang export_to_flangtargets UMBRELLA flang-libraries)
       install(TARGETS ${name}

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 
 set(MLIR_TOOLS_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH
     "Path for binary subdirectory (defaults to '${CMAKE_INSTALL_BINDIR}')")
+option(MLIR_INSTALL_TOOLCHAIN_ONLY "Do not install MLIR libraries unless they belong to the toolchain" OFF)
 mark_as_advanced(MLIR_TOOLS_INSTALL_DIR)
 
 set(MLIR_MAIN_SRC_DIR     ${CMAKE_CURRENT_SOURCE_DIR}  )

--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -2,6 +2,7 @@ include(TableGen)
 include(GNUInstallDirs)
 include(LLVMDistributionSupport)
 
+
 function(mlir_tablegen ofn)
   tablegen(MLIR ${ARGV})
   set(TABLEGEN_OUTPUT ${TABLEGEN_OUTPUT} ${CMAKE_CURRENT_BINARY_DIR}/${ofn}
@@ -632,8 +633,12 @@ endfunction(add_mlir_aggregate)
 # This is usually done as part of add_mlir_library but is broken out for cases
 # where non-standard library builds can be installed.
 function(add_mlir_library_install name)
+  message("add_mlir_library_install(${name})")
+  message("MLIR_INSTALL_TOOLCHAIN_ONLY: ${MLIR_INSTALL_TOOLCHAIN_ONLY}")
+  message("LLVM_INSTALL_TOOLCHAIN_ONLY: ${LLVM_INSTALL_TOOLCHAIN_ONLY}")
   get_target_property(_install_with_toolchain ${name} MLIR_INSTALL_WITH_TOOLCHAIN)
-  if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY OR _install_with_toolchain)
+  if ((NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND NOT MLIR_INSTALL_TOOLCHAIN_ONLY) OR _install_with_toolchain)
+    message("installing ${name}")
     get_target_export_arg(${name} MLIR export_to_mlirtargets UMBRELLA mlir-libraries)
     install(TARGETS ${name}
       COMPONENT ${name}


### PR DESCRIPTION
MLIR_INSTALL_TOOLCHAIN_ONLY is a misnormer as MLIR is not part of a compiler toolchain